### PR TITLE
feat(lazy load): add manifest support for resolve

### DIFF
--- a/docs/ANGULAR-LAZY-COMPONENT.md
+++ b/docs/ANGULAR-LAZY-COMPONENT.md
@@ -23,8 +23,8 @@ ModuleRegistry.registerComponent('Prefix.componentName', () => MyNgComp);
 * `files`: Array of url strings and sub arrays of url strings.  
 Every **url string** in the main array will be **loaded independently**.  
 Using a **sub array** allows to **serialize** the download of its items.  
-* `resolve`(optional): A function to fetch data **before** bootstrap and **in parallel** of downloading the `files`.
-* `prepare`(optional): A function to prepare data **before** bootstrap and **after** all `files` were downloaded and `resolve` resolved.
+* `resolve`(optional): A function (`() => Promise<object>`) to fetch data **before** bootstrap and **in parallel** of downloading the `files`.
+* `prepare`(optional): A function (`() => Promise<any> || void`) to prepare data **before** bootstrap and **after** all `files` were downloaded and `resolve` resolved.
 * `module`: The name of the angular module that will be bootstrapped.  
 * `component`: The name of your angular application's root directive/component that should be rendered.  
 * `unloadStylesOnDestroy`(optional, default false): Specifies if loaded stylesheets should be unloaded when component is destroyed.

--- a/docs/ANGULAR-LAZY-COMPONENT.md
+++ b/docs/ANGULAR-LAZY-COMPONENT.md
@@ -23,21 +23,32 @@ ModuleRegistry.registerComponent('Prefix.componentName', () => MyNgComp);
 * `files`: Array of url strings and sub arrays of url strings.  
 Every **url string** in the main array will be **loaded independently**.  
 Using a **sub array** allows to **serialize** the download of its items.  
-* `prepare`(optional): A function to prepare data before bootstrap.  
+* `resolve`(optional): A function to fetch data **before** bootstrap and **in parallel** of downloading the `files`.
+* `prepare`(optional): A function to prepare data **before** bootstrap and **after** all `files` were downloaded and `resolve` resolved.
 * `module`: The name of the angular module that will be bootstrapped.  
 * `component`: The name of your angular application's root directive/component that should be rendered.  
-* `unloadStylesOnDestroy`(optional, default false): Specifies if loaded stylesheets should be unloaded when component is destroyed.  
+* `unloadStylesOnDestroy`(optional, default false): Specifies if loaded stylesheets should be unloaded when component is destroyed.
+  
+##### Please note
+* The `resolve` function must return a `promise`. Common usage for `resolve` would be to fetch data that affects how your app is rendered, like **experiments** or **user privileges**.
+* The `prepare` function can return a new promise if asynchronous behaviour is required.
 
 ### Explanation
-Before being rendered all of the required `files` will be loaded.  
-Once all `files` are loaded, the function `prepare` will be executed.  
-The `prepare` function can return a new promise if asynchronous behaviour is required.  
+Before being rendered, all of the required `files` will be downloaded and `resolve` will executed.  
+Once all `files` are loaded and `resolve` resolved, the function `prepare` will be executed.    
 Once `prepare` finished/resolved `angular.bootstrap()` will be called with the component and module you passed.  
 
 ### Example
 ```js
 {
   files: ['y.js', `${props.files.fakeFile}`, ['1.js', '2.js', '3.js'], 'z.js'],
+  resolve: () => {
+    return fetchExperiments().then(response => {
+      return {
+        experiments: response.data // experiments would be available on the props service
+      };
+    });
+  },
   prepare: () => {
     // customLogic();
     // or

--- a/docs/REACT-LAZY-COMPONENT.md
+++ b/docs/REACT-LAZY-COMPONENT.md
@@ -23,6 +23,7 @@ You should register the new lazy component using `ModuleRegistry.registerCompone
      //see manifest explanation below
      const manifest = {
        files: ['src/main-component.js'],
+       resolve: () => { /* fetch some data */ }, // optional
        component: 'appName.mainComponentName'
      };
      super(props, manifest);
@@ -38,20 +39,31 @@ You should register the new lazy component using `ModuleRegistry.registerCompone
 ### Fields
 * `files`: Array of url strings and sub arrays of url strings.  
 Every **url string** in the main array will be **loaded independently**.  
-Using a **sub array** allows to **serialize** the download of its items.  
-* `component`: The name you used to register your main react component to the `ModuleRegistry`.  
+Using a **sub array** allows to **serialize** the download of its items.
+* `resolve`(optional): A function which will execute **in parallel of downloading the** `files`.
+* `component`: The name you used to register your main react component to the `ModuleRegistry`.
+  
+##### Please note
+* The `resolve` function must return a `promise`. Common usage for `resolve` would be to fetch data that affects how your app is rendered, like **experiments** or **user privileges**.  
 
 ### Example
 ```js 
 {
   files: ['y.js', `${props.files.fakeFile}`, ['1.js', '2.js', '3.js'], 'z.js'],
+  resolve: () => {
+    return fetchExperiments().then(response => {
+      return {
+        experiments: response.data // experiments would be available on the props
+      };
+    });
+  },
   component: 'Prefix.mainComponentName'
 }
 ```
 
 ### Explanation
-When the host tries to render the lazy component, it starts by loading all the required `files`.  
-Once all `files` are loaded, the component is rendered and receives the props parameter as `props`.  
+When the host tries to render the lazy component, it starts by downloading all the required `files` and execute `resolve`.  
+Once all `files` are loaded and `resolve` resolved, the component is rendered and receives the props parameter as `props`.  
 
 ### Lifecycle events
 All lazy components fire 3 lifecycle events (Via the ModuleRegistry):

--- a/docs/REACT-LAZY-COMPONENT.md
+++ b/docs/REACT-LAZY-COMPONENT.md
@@ -40,7 +40,7 @@ You should register the new lazy component using `ModuleRegistry.registerCompone
 * `files`: Array of url strings and sub arrays of url strings.  
 Every **url string** in the main array will be **loaded independently**.  
 Using a **sub array** allows to **serialize** the download of its items.
-* `resolve`(optional): A function which will execute **in parallel of downloading the** `files`.
+* `resolve`(optional): A function (`() => Promise<object>`) which will execute **in parallel of downloading the** `files`.
 * `component`: The name you used to register your main react component to the `ModuleRegistry`.
   
 ##### Please note

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "start": "yoshi start --entry-point=./dist/test/mock/fake-server.js",
-    "build": "yoshi lint && yoshi build",
+    "build": ":",
+    "pretest": "yoshi lint && yoshi build",
     "test": "yoshi test",
     "release": "yoshi release"
   },
@@ -57,7 +58,7 @@
     ]
   },
   "dependencies": {
-    "lodash": "^4.16.0",
+    "lodash": "^4.17.4",
     "react": "^15.3.2",
     "react-dom": "^15.3.2"
   }

--- a/src/demo/module.js
+++ b/src/demo/module.js
@@ -15,6 +15,16 @@ export class MyNgComp2 extends AngularLazyComponent {
   constructor(props) {
     super(props, {
       files: [`${props.topology.staticsUrl}angular-module.bundle.js`],
+      resolve: () => {
+        const experimentsPromise = Promise.resolve({'specs.fed.ReactModuleContainerWithResolve': true});
+        const customDataPromise = Promise.resolve({user: 'xiw@wix.com'});
+        return Promise.all([experimentsPromise, customDataPromise]).then(results => {
+          return {
+            experiments: results[0],
+            customData: results[1]
+          };
+        });
+      },
       module: 'myApp2',
       component: 'my-comp'
     });
@@ -25,6 +35,16 @@ export class MyReactComp extends ReactLazyComponent {
   constructor(props) {
     super(props, {
       files: [`${props.topology.staticsUrl}react-module.bundle.js`],
+      resolve: () => {
+        const experimentsPromise = Promise.resolve({'specs.fed.ReactModuleContainerWithResolve': true});
+        const customDataPromise = Promise.resolve({user: 'xiw@wix.com'});
+        return Promise.all([experimentsPromise, customDataPromise]).then(results => {
+          return {
+            experiments: results[0],
+            customData: results[1]
+          };
+        });
+      },
       component: 'MyApp3.RealReactComp'
     });
   }

--- a/src/lazy/angular-module.js
+++ b/src/lazy/angular-module.js
@@ -51,6 +51,8 @@ myApp2.component('myComp', {
   template:
   `<div>
     <div id="value-in-angular">{{$ctrl.props().value}}</div>
+    <div id="value-of-resolved-experiments">{{$ctrl.props().experiments}}</div>
+    <div id="value-of-resolved-custom-data">{{$ctrl.props().customData}}</div>
     <input id="angular-input" ng-model="$ctrl.value" />
     <div>
       <a id="bazinga" ui-sref="a">a</a>

--- a/src/lazy/react-module.js
+++ b/src/lazy/react-module.js
@@ -4,7 +4,9 @@ import ModuleRegistry from '../module-registry';
 
 const RealReactComp = props => (
   <div>
-    <span>{props.value}</span>
+    <div>{props.value}</div>
+    <div id="value-of-resolved-experiments">{JSON.stringify(props.experiments)}</div>
+    <div id="value-of-resolved-custom-data">{JSON.stringify(props.customData)}</div>
     <div>
       <Link className={'react-link'} to="/ng-router-app/a">ng-route-app</Link>&nbsp;
       <Link className={'react-link'} to="/ui-router-app/">ui-route-app</Link>&nbsp;
@@ -12,6 +14,8 @@ const RealReactComp = props => (
   </div>
 );
 RealReactComp.propTypes = {
-  value: React.PropTypes.any
+  value: React.PropTypes.any,
+  experiments: React.PropTypes.any,
+  customData: React.PropTypes.any
 };
 ModuleRegistry.registerComponent('MyApp3.RealReactComp', () => RealReactComp);

--- a/src/react-lazy-component.js
+++ b/src/react-lazy-component.js
@@ -1,35 +1,22 @@
 import React from 'react';
-import {filesAppender} from './tag-appender';
 import ModuleRegistry from './module-registry';
+import BaseLazyComponent from './base-lazy-component';
 
-class ReactLazyComponent extends React.Component {
+class ReactLazyComponent extends BaseLazyComponent {
   constructor(props, manifest) {
-    super(props);
-    this.manifest = manifest;
+    super(props, manifest);
     this.state = {component: null};
   }
 
-  componentWillMount() {
-    ModuleRegistry.notifyListeners('reactModuleContainer.componentStartLoading', this.manifest.component);
-    this.filesAppenderPromise = filesAppender(this.manifest.files);
-    this.resolvePromise = this.manifest.resolve ? this.manifest.resolve() : Promise.resolve({});
-  }
-
   componentDidMount() {
-    Promise.all([this.filesAppenderPromise, this.resolvePromise]).then(results => {
-      this.resolvedProps = results[1];
-      ModuleRegistry.notifyListeners('reactModuleContainer.componentReady', this.manifest.component);
+    this.resourceLoader.then(() => {
       const component = ModuleRegistry.component(this.manifest.component);
       this.setState({component});
     });
   }
 
-  componentWillUnmount() {
-    ModuleRegistry.notifyListeners('reactModuleContainer.componentWillUnmount', this.manifest.component);
-  }
-
   render() {
-    return this.state.component ? <this.state.component {...this.props} {...this.resolvedProps}/> : null;
+    return this.state.component ? <this.state.component {...this.mergedProps}/> : null;
   }
 }
 

--- a/test/e2e/app.e2e.js
+++ b/test/e2e/app.e2e.js
@@ -101,6 +101,16 @@ describe('React application', () => {
     }));
   });
 
+  describe('manifest with resolve', () => {
+    ['ui', 'rt'].forEach(router => describe(`/${router}-router-app/`, () => {
+      it(`should display the resolved data`, () => {
+        browser.get(`/${router}-router-app/`);
+        expect($('#value-of-resolved-experiments').getText()).toBe(JSON.stringify({'specs.fed.ReactModuleContainerWithResolve': true}));
+        expect($('#value-of-resolved-custom-data').getText()).toBe(JSON.stringify({user: 'xiw@wix.com'}));
+      });
+    }));
+  });
+
   function getStyleSheetHrefs() {
     return $$('link').map(elem => elem.getAttribute('href'));
   }


### PR DESCRIPTION
This is an early-stage PR for adding support for `resolve` property in the manifest

Motivation: while the browsing is (lazy) downloading the manifest files, we can simultaneously do ajax request to fetch custom data before rendering the widget