### PR TITLE
Allow global loading via UMD bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "externals": {
       "react": "React",
       "react-dom": "ReactDOM"
-    }
+    },
+    "exports": "reactModuleContainer"
   },
   "devDependencies": {
     "babel-plugin-transform-builtin-extend": "^1.1.2",


### PR DESCRIPTION
I'd like to load `reactModuleContainer` as a UMD bundle via URL rather than bundling it in my bundle.  
This change adds export for `reactModuleContainer` which will make it available on global object.