### PR TITLE
react-loadable-component fallback

### DIFF
--- a/src/react-loadable-component.js
+++ b/src/react-loadable-component.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import BaseLazyComponent from './base-lazy-component';
 
-export default function ReactLoadableComponent(name, resolve, files = []) {
+export default function ReactLoadableComponent(name, resolve, files = [], fallback = null) {
   return class LoadableComponent extends BaseLazyComponent {
     constructor(props) {
       super(props, {component: name, files, resolve});
@@ -16,7 +16,7 @@ export default function ReactLoadableComponent(name, resolve, files = []) {
     }
 
     render() {
-      return this.state.component ? <this.state.component {...this.mergedProps}/> : null;
+      return this.state.component ? <this.state.component {...this.mergedProps}/> : fallback;
     }
   };
 }


### PR DESCRIPTION
For components that are not loaded by the platform, but by another component, no loader is displayed. We wish to be able to show a loader while `react-loadable-component` fetches all resources. 