### PR TITLE
add `isComponentRegistered` method

### DIFF
--- a/src/module-registry.js
+++ b/src/module-registry.js
@@ -50,6 +50,10 @@ class ModuleRegistry {
     }
     return generator();
   }
+  
+  isComponentRegistered(globalID) {
+    return !!this.registeredComponents[globalID]; 
+  }
 
   addListener(globalID, callback) {
     const callbackKey = uniqueId('eventListener');


### PR DESCRIPTION
Currently the only way to check if the component is registered is to invoke `ModuleRegistry.component` and check for result. However, in this case if the component is not registered there is an error thrown.  
We need a noiseless way to check whether component registered or not, in order to invoke  `ModuleRegistry.component` for registered components only to avoid unnecessary errors.  